### PR TITLE
feat: add verified accounts

### DIFF
--- a/app/rules/rules.type.ts
+++ b/app/rules/rules.type.ts
@@ -32,6 +32,7 @@ export const ruleNames = [
   "hasIcebreakerQBuilder",
   "hasIcebreakerVerified",
   "hasIcebreakerCredential",
+  "hasIcebreakerLinkedAccount",
 ] as const;
 
 export type RuleName = (typeof ruleNames)[number];
@@ -99,7 +100,6 @@ export type CheckFunctionArgs = {
   user: User;
   rule: Rule;
 };
-
 
 export type SelectOption = {
   label: string;


### PR DESCRIPTION
- Adds new rule function to check for a linked account
- Allows for optionally choosing that the account must be verified (by icebreaker or any other verification platform that Icebreaker knows about)
- Allows rule to be used multiple times to let moderators require multiple linked accounts